### PR TITLE
Update documentation generation logic with Travis CI

### DIFF
--- a/.travis-generate-docs.sh
+++ b/.travis-generate-docs.sh
@@ -5,12 +5,6 @@ set -e # Exit with nonzero exit code if anything fails
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
-# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Skipping documentation generation; just doing a build."
-    exit 0
-fi
-
 echo "Generating docs with PHPDocumentor..."
 phpdoc -c phpdoc.xml --visibility=public # Since we've added vendor/bin to the PATH variable, we can just execute phpdoc now.
 
@@ -47,5 +41,12 @@ Latest docs on successful travis build $TRAVIS_BUILD_NUMBER
 ValidForm Builder commit $TRAVIS_COMMIT
 EOF
 
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+    echo "Skipping documentation generation; just doing a build."
+    exit 0
+fi
+
+# Commit the generated docs to the master branch
 git push https://${GH_TOKEN}:@github.com/neverwoods/validformbuilder.git HEAD:${TARGET_BRANCH} > /dev/null 2>&1 || exit 1
 echo "Published docs to ${TARGET_BRANCH}."

--- a/.travis-generate-docs.sh
+++ b/.travis-generate-docs.sh
@@ -43,7 +43,7 @@ EOF
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Skipping documentation generation; just doing a build."
+    echo "We will not commit generated documentation to the master branch. Only builds from the master branch will be committed."
     exit 0
 fi
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
         "psr-0": {"ValidFormBuilder": "classes/"}
     },
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "~2.9"
-    }
+        "phpdocumentor/phpdocumentor": "dev-master"
+    },
+    "repositories": [
+        {
+            "url": "https://github.com/validformbuilder/phpdocumentor2.git",
+            "type": "vcs"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr-0": {"ValidFormBuilder": "classes/"}
     },
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "dev-master"
+        "phpdocumentor/phpdocumentor": "dev-develop"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "psr-0": {"ValidFormBuilder": "classes/"}
     },
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "dev-master"
+        "phpdocumentor/phpdocumentor": "~2.9"
     }
 }


### PR DESCRIPTION
The latest version of `phpDocumentor2` was using `jms/serializer` version `>=0.12`

Since the `jms/serializer` recently published version `1.8.0`, `phpDocumentor2` was loading that new version. But in version `1.8.0`, they introduced a backwards compatibility break/bug. This was causing phpDocumentor to trip and thus build errors in Travis CI.

Solution: Forked phpDocumentor into `validformbuilder/phpDocumentor2` and set the `jms/serializer` version to `1.7.*` since in the last successful build we used `1.7.1`. Then updated the ValidForm Builder dependency to point to this fork and we're back on track.

Also, to detect these issues faster in the future, I updated the bash script that generates the documentation. Instead of cancelling the script when it's not executed for the master branch, it now runs the documentation generator all the way up to the point where it is committed to the `gh-pages` branch. That step is skipped if the branch we're building is not `master`.